### PR TITLE
fix: remove catch dependency

### DIFF
--- a/ext/CMakeLists.txt
+++ b/ext/CMakeLists.txt
@@ -41,20 +41,20 @@ ExternalProject_Get_Property(spdlog source_dir)
 set(SPDLOG_INCLUDE_DIR ${source_dir}/include CACHE INTERNAL "./ext/spdlog/include")
 
 # Catch
-ExternalProject_Add(
-    catch
-    PREFIX ${CMAKE_BINARY_DIR}/ext/catch
-    GIT_REPOSITORY https://github.com/philsquared/Catch.git
-    TIMEOUT 10
-    UPDATE_COMMAND ${GIT_EXECUTABLE} pull
-    CONFIGURE_COMMAND ""
-    BUILD_COMMAND ""
-    INSTALL_COMMAND ""
-    LOG_DOWNLOAD ON
-    )
+# ExternalProject_Add(
+#     catch
+#     PREFIX ${CMAKE_BINARY_DIR}/ext/catch
+#     GIT_REPOSITORY https://github.com/philsquared/Catch.git
+#     TIMEOUT 10
+#     UPDATE_COMMAND ${GIT_EXECUTABLE} pull
+#     CONFIGURE_COMMAND ""
+#     BUILD_COMMAND ""
+#     INSTALL_COMMAND ""
+#     LOG_DOWNLOAD ON
+#     )
 
-ExternalProject_Get_Property(catch source_dir)
-set(CATCH_INCLUDE_DIR ${source_dir}/single_include CACHE INTERNAL "./ext/catch/include")
+# ExternalProject_Get_Property(catch source_dir)
+# set(CATCH_INCLUDE_DIR ${source_dir}/single_include CACHE INTERNAL "./ext/catch/include")
 
 ##
 

--- a/src/market/book.cpp
+++ b/src/market/book.cpp
@@ -254,7 +254,7 @@ bool Book<C, DEPTH>::PlaceOrder(double price, long size)
     if (OrderExists(it))
         return false;
     else {
-        open_orders.emplace(price, make_unique<Order>(price, size, volume(price)));
+        open_orders.emplace(price, unique_ptr<Order>(new Order(price, size, volume(price))));
 
         return true;
     }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,14 +1,14 @@
 file(GLOB_RECURSE TEST_FILES RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} *.cpp)
 
-include_directories(${CATCH_INCLUDE_DIR})
+find_package(Catch2 REQUIRED)
 
-# add_catch_test(<target> <sources>...)
-function(add_catch_test target)
-    add_executable(${target} main.cpp ${ARGN})
-    target_link_libraries(${target}
-        rl_engine)
+# Create test executable
+add_executable(do_tests main.cpp ${TEST_FILES})
 
-    add_test(${target} ${CMAKE_BINARY_DIR}/${target})
-endfunction()
+target_link_libraries(do_tests PRIVATE 
+    Catch2::Catch2WithMain  
+    rl_engine
+)
 
-add_catch_test(do_tests ${TEST_FILES})
+# Add test
+add_test(NAME do_tests COMMAND do_tests)

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -1,2 +1,2 @@
 #define CATCH_CONFIG_MAIN
-#include "catch.hpp"
+#include <catch2/catch_all.hpp>

--- a/test/test_Accumulators.cpp
+++ b/test/test_Accumulators.cpp
@@ -1,4 +1,4 @@
-#include "catch.hpp"
+#include <catch2/catch_all.hpp>
 #include "utilities/accumulators.h"
 
 using namespace std;
@@ -11,13 +11,13 @@ SCENARIO("a sequence of values 1:1:5", "[Accumulator][RollingMedian]") {
         for (int i = 1; i <= 3; i++)
             rm.push((float) i);
 
-        REQUIRE(rm.mean() == Approx(2.0f));
-        REQUIRE(rm.var() == Approx(1.0f));
+        REQUIRE(rm.mean() == Catch::Approx(2.0f));
+        REQUIRE(rm.var() == Catch::Approx(1.0f));
 
         for (int i = 4; i <= 5; i++) {
             rm.push(i);
-            REQUIRE(rm.mean() == Approx(i-1.0f));
-            REQUIRE(rm.var() == Approx(1.0f));
+            REQUIRE(rm.mean() == Catch::Approx(i-1.0f));
+            REQUIRE(rm.var() == Catch::Approx(1.0f));
         }
     }
 
@@ -28,7 +28,7 @@ SCENARIO("a sequence of values 1:1:5", "[Accumulator][RollingMedian]") {
             rm.push((float) i);
 
         THEN("the median should be 3") {
-            REQUIRE(rm.median() == Approx(3.0f));
+            REQUIRE(rm.median() == Catch::Approx(3.0f));
         }
     }
 }
@@ -42,16 +42,16 @@ SCENARIO("a sequence of values 10.5, 11.5, 11.5, 11.5, 12.5", "[Accumulator][Rol
         rm.push(11.5);
         rm.push(11.5);
 
-        REQUIRE(rm.mean() == Approx(11.1667f));
-        REQUIRE(rm.var() == Approx(1.0f / 3));
+        REQUIRE(rm.mean() == Catch::Approx(11.1667f));
+        REQUIRE(rm.var() == Catch::Approx(1.0f / 3));
 
         rm.push(11.5);
-        REQUIRE(rm.mean() == Approx(11.5f));
-        REQUIRE(rm.var() == Approx(0.0f).scale(1.0f));
+        REQUIRE(rm.mean() == Catch::Approx(11.5f));
+        REQUIRE(rm.var() == Catch::Approx(0.0f).scale(1.0f));
 
         rm.push(12.5);
-        REQUIRE(rm.mean() == Approx(11.8333f));
-        REQUIRE(rm.var() == Approx(1.0f / 3));
+        REQUIRE(rm.mean() == Catch::Approx(11.8333f));
+        REQUIRE(rm.var() == Catch::Approx(1.0f / 3));
     }
 
     GIVEN("a rolling median") {
@@ -64,7 +64,7 @@ SCENARIO("a sequence of values 10.5, 11.5, 11.5, 11.5, 12.5", "[Accumulator][Rol
         rm.push(12.5);
 
         THEN("the median should be 3") {
-            REQUIRE(rm.median() == Approx(11.5f));
+            REQUIRE(rm.median() == Catch::Approx(11.5f));
         }
     }
 }

--- a/test/test_Book.cpp
+++ b/test/test_Book.cpp
@@ -1,4 +1,4 @@
-#include "catch.hpp"
+#include <catch2/catch_all.hpp>
 #include "market/book.h"
 #include "utilities/comparison.h"
 
@@ -11,6 +11,7 @@ typedef std::map<double, long, FloatComparator<>> TMAP;
 SCENARIO("book handles market depth data", "[Market][Book]") {
 
     GIVEN("an ask book with 2 levels") {
+        printf("VARI CORINTHIANS \n");
         market::AskBook<2> book;
 
         array<double, 2> prices{100.0, 200.0};

--- a/test/test_Market.cpp
+++ b/test/test_Market.cpp
@@ -1,4 +1,4 @@
-#include "catch.hpp"
+#include <catch2/catch_all.hpp>
 #include "market/market.h"
 
 using namespace std;
@@ -94,7 +94,7 @@ SCENARIO("CRDI.MI", "[Market]") {
         }
 
         THEN("a round trip should round the price up to the nearest tick") {
-            REQUIRE(m->ToPrice(m->ToTicks(1.96885)) == Approx(1.969));
+            REQUIRE(m->ToPrice(m->ToTicks(1.96885)) == Catch::Approx(1.969));
         }
     }
 }

--- a/test/test_Order.cpp
+++ b/test/test_Order.cpp
@@ -1,4 +1,4 @@
-#include "catch.hpp"
+#include <catch2/catch_all.hpp>
 #include "market/order.h"
 
 using namespace std;


### PR DESCRIPTION
## Fix the Catch dependency

Description: I tried running the code and an issue with the Catch package appered. The problem is that they've changed the Catch package repository (now called Catch2)  so the 

Fix: the PR removes the old installation of Catch and fixes its dependencies so now it need to be installed before trying to compile this project. The following script installs Catch2:
```bash
git clone https://github.com/catchorg/Catch2.git
cd Catch2
cmake -Bbuild -H. -DBUILD_TESTING=OFF
sudo cmake --build build/ --target install
```
Then just compiles the project the way described in the README file.